### PR TITLE
🔧 Add Redis configuration to Kubevisor Chart

### DIFF
--- a/incubator/kubevisor/templates/operator/configMap.yaml
+++ b/incubator/kubevisor/templates/operator/configMap.yaml
@@ -14,5 +14,7 @@ metadata:
 data:
   KUBEVISOR_STATUS_IMAGE_NAME: "{{ .Values.operator.statusImage.name }}:{{ .Values.operator.statusImage.tag }}"
   KUBEVISOR_STATUS_IMAGE_PULL_POLICY: {{ .Values.operator.statusImage.pullPolicy }}
+  KUBEVISOR_REDIS_IMAGE: "{{ .Values.operator.redis.image.name }}:{{ .Values.operator.redis.image.tag }}"
+  KUBEVISOR_REDIS_IMAGE_PULL_POLICY: {{ .Values.operator.redis.image.pullPolicy }}
   KUBEVISOR_SERVICEACCOUNT: {{ .Values.operator.serviceAccountName }}
 {{- end -}}

--- a/incubator/kubevisor/templates/operator/statefulset.yaml
+++ b/incubator/kubevisor/templates/operator/statefulset.yaml
@@ -58,6 +58,8 @@ spec:
           env:
             - name: RABBITMQ_URL
               {{ .Values.operator.rabbitUrl | toYaml | nindent 14 }}
+            - name: KUBEVISOR_REDIS_HOST
+              {{ .Values.operator.redis.host | toYaml | nindent 14 }}
           envFrom:
             - configMapRef:
                 name: {{ include "kubevisor.fullname" . }}-operator

--- a/incubator/kubevisor/values.yaml
+++ b/incubator/kubevisor/values.yaml
@@ -15,6 +15,15 @@ operator:
     tag: latest
     pullPolicy: IfNotPresent
 
+  redis:
+    host:
+      value: http://localhost:6739
+
+    image:
+      name: redis
+      tag: alpine
+      pullPolicy: IfNotPresent
+
   serviceAccountName: default
 
   rabbitUrl:


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :wrench: Add Redis options to `values.yaml`
 - [x] :lock: `KUBEVISOR_REDIS_HOST` can be set through a secret
 - [x] :wrench: Update `ConfigMap` to fill Kubevisor's environment with Redis options