### PR TITLE
📦 Add Kubevisor cURL Unit chart

### DIFF
--- a/incubator/kubevisor-curl-unit/.helmignore
+++ b/incubator/kubevisor-curl-unit/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/incubator/kubevisor-curl-unit/Chart.yaml
+++ b/incubator/kubevisor-curl-unit/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: kubevisor-curl-unit
+description: Parametrable cURL Unit for Kubevisor
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/incubator/kubevisor-curl-unit/templates/_helpers.tpl
+++ b/incubator/kubevisor-curl-unit/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kubevisor-curl-unit.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kubevisor-curl-unit.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubevisor-curl-unit.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kubevisor-curl-unit.labels" -}}
+helm.sh/chart: {{ include "kubevisor-curl-unit.chart" . }}
+{{ include "kubevisor-curl-unit.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kubevisor-curl-unit.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubevisor-curl-unit.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kubevisor-curl-unit.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kubevisor-curl-unit.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/incubator/kubevisor-curl-unit/templates/unit.yaml
+++ b/incubator/kubevisor-curl-unit/templates/unit.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kubevisor.io/v1
+kind: Unit
+metadata:
+  name: {{ include "kubevisor-curl-unit.fullname" . }}
+  labels:
+    {{- include "kubevisor-curl-unit.labels" . | nindent 4 }}
+    {{ .Values.labels | toYaml | nindent 4 }}
+spec:
+  schedule: {{ .Values.schedule }}
+  image:
+    name: {{ .Values.image.name }}
+    pullPolicy: {{ .Values.image.pullPolicy }}
+    command: "curl -L {{ .Values.args }} $HOST"
+  env:
+    - name: HOST
+      {{ .Values.host | toYaml | nindent 14 }}

--- a/incubator/kubevisor-curl-unit/values.yaml
+++ b/incubator/kubevisor-curl-unit/values.yaml
@@ -1,0 +1,18 @@
+---
+
+# User Configuration
+
+schedule: every 5 minutes
+
+host:
+  value: http://example.com
+
+labels: {}
+
+# Internal Configuration (can be overidden)
+
+image:
+  name: curlimages/curl:latest
+  pullPolicy: IfNotPresent
+
+args: '-v'


### PR DESCRIPTION
This PR adds a [Kubevisor Unit](https://kubevisor.io/docs/concepts/unit/) for [cURL](https://curl.se/) as an Helm Chart.

## When will this PR be ready?

 - [x] :lock: Allow `HOST` environment variable to be set as a secret
 - [x] :wrench: Provide default configuration for Docker image

## Usage

```
helm install google-access link-society-incubator/kubevisor-curl-unit \
    --namespace default \
    --set schedule="every 5 minutes" \
    --set host.value="https://www.google.com"
```


