### PR TITLE
🐛 Fix Generated YAML in kubevisor-curl-unit

### DIFF
--- a/incubator/kubevisor-curl-unit/templates/unit.yaml
+++ b/incubator/kubevisor-curl-unit/templates/unit.yaml
@@ -5,7 +5,9 @@ metadata:
   name: {{ include "kubevisor-curl-unit.fullname" . }}
   labels:
     {{- include "kubevisor-curl-unit.labels" . | nindent 4 }}
+    {{ if .Values.labels }}
     {{ .Values.labels | toYaml | nindent 4 }}
+    {{ end}}
 spec:
   schedule: {{ .Values.schedule }}
   image:
@@ -14,4 +16,4 @@ spec:
     command: "curl -L {{ .Values.args }} $HOST"
   env:
     - name: HOST
-      {{ .Values.host | toYaml | nindent 14 }}
+      {{ .Values.host | toYaml | nindent 6 }}


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :bug: Do not print `.Values.labels` if falsy
 - [x] :bug: Fix indentation for HOST variable 