### PR TITLE
🐛 envFrom is an array in Kubevisor chart

### DIFF
--- a/incubator/kubevisor/templates/dashboard/deployment.yaml
+++ b/incubator/kubevisor/templates/dashboard/deployment.yaml
@@ -32,6 +32,6 @@ spec:
               containerPort: 80
               protocol: TCP
           envFrom:
-            configMap:
-              name: {{ include "kubevisor.fullname" . }}-dashboard
+            - configMapRef:
+                name: {{ include "kubevisor.fullname" . }}-dashboard
 {{- end -}}


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :bug: Replace `envFrom` by an array
