### PR TITLE
🐛 Add missing serviceName to StatefulSet

### DIFF
--- a/incubator/kubevisor/templates/operator/statefulset.yaml
+++ b/incubator/kubevisor/templates/operator/statefulset.yaml
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: kubevisor
 spec:
+  serviceName: {{ include "kubevisor.fullname" . }}-operator
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :bug: StatefulSets require a `serviceName` property