### PR TITLE
🐛 Add container registry to images in Kubevisor chart

### DIFF
--- a/incubator/kubevisor/templates/dashboard/deployment.yaml
+++ b/incubator/kubevisor/templates/dashboard/deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: dashboard
-          image: "{{ .Values.dashboard.image.name }}:{{ .Values.dashboard.image.tag }}"
+          image: "{{ .Values.container.registry }}/{{ .Values.dashboard.image.name }}:{{ .Values.dashboard.image.tag }}"
           imagePullPolicy: {{ .Values.dashboard.image.pullPolicy }}
           ports:
             - name: http

--- a/incubator/kubevisor/templates/operator/statefulset.yaml
+++ b/incubator/kubevisor/templates/operator/statefulset.yaml
@@ -47,7 +47,7 @@ spec:
               fi
       containers:
         - name: node
-          image: "{{ .Values.operator.image.name }}:{{ .Values.operator.image.tag }}"
+          image: "{{ .Values.container.registry }}/{{ .Values.operator.image.name }}:{{ .Values.operator.image.tag }}"
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
           volumeMounts:
             - name: node-runtime


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :bug: Use `container.registry` chart value in image specs