### PR TITLE
🐛 Fix default container registry URL in Kubevisor Chart

### DIFF
--- a/incubator/kubevisor/values.yaml
+++ b/incubator/kubevisor/values.yaml
@@ -1,5 +1,5 @@
 container:
-  registry: npm.pkg.github.io/link-society
+  registry: docker.pkg.github.io/link-society
 
 operator:
   enabled: yes


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :wrench: Use docker registry URL instead of npm 😅