### PR TITLE
🐛 Fix dashboard image name in Kubevisor Chart

### DIFF
--- a/incubator/kubevisor/values.yaml
+++ b/incubator/kubevisor/values.yaml
@@ -34,7 +34,7 @@ dashboard:
 
   replicas: 3
   image:
-    name: kubevisor/kubevisor-dashboard
+    name: kubevisor-dashboard/kubevisor-dashboard
     tag: latest
     pullPolicy: Always
 


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :wrench: Fix Kubevisor Dashboard image name
