### PR TITLE
🐛 Fix registry URL in Kubevisor Chart

### DIFF
--- a/incubator/kubevisor/templates/operator/statefulset.yaml
+++ b/incubator/kubevisor/templates/operator/statefulset.yaml
@@ -27,7 +27,7 @@ spec:
       terminationGracePeriodSeconds: 10
       initContainers:
         - name: init-node-runtime
-          image: "{{ .Values.operator.image.name }}:{{ .Values.operator.image.tag }}"
+          image: "{{ .Values.container.registry }}/{{ .Values.operator.image.name }}:{{ .Values.operator.image.tag }}"
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
           volumeMounts:
             - name: node-runtime

--- a/incubator/kubevisor/values.yaml
+++ b/incubator/kubevisor/values.yaml
@@ -1,5 +1,5 @@
 container:
-  registry: docker.pkg.github.io/link-society
+  registry: docker.pkg.github.com/link-society
 
 operator:
   enabled: yes


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :wrench: Set Docker Registry URL to [docker.pkg.github.com]() 😅