### PR TITLE
🐛 Fix ingress and dashboard config in Kubevisor chart

### DIFF
--- a/incubator/kubevisor/templates/dashboard/configMap.yaml
+++ b/incubator/kubevisor/templates/dashboard/configMap.yaml
@@ -13,6 +13,6 @@ metadata:
     app.kubernetes.io/part-of: kubevisor
 data:
   KUBEVISOR_TOKEN_NAME: kubevisor-token
-  KUBEVISOR_GRAPHQL_ENDPOINT_HTTP: http://{{ include "kubevisor.fullname" . }}-operator/graphql
-  KUBEVISOR_GRAPHQL_ENDPOINT_WS: ws://{{ include "kubevisor.fullname" . }}-operator/graphql
+  KUBEVISOR_GRAPHQL_ENDPOINT_HTTP: {{ .Values.dashboard.graphqlEndpoint.http }}
+  KUBEVISOR_GRAPHQL_ENDPOINT_WS: {{ .Values.dashboard.graphqlEndpoint.ws }}
 {{- end -}}

--- a/incubator/kubevisor/templates/ingress.yaml
+++ b/incubator/kubevisor/templates/ingress.yaml
@@ -25,12 +25,12 @@ spec:
     - host: {{ .Values.ingress.host }}
       http:
         paths:
-{{- if .Values.operator.enabled -}}
-          - path: /operator
+{{- if .Values.controller.enabled -}}
+          - path: /controller
             pathType: Prefix
             backend:
               service:
-                name: {{ include "kubevisor.fullname" . }}-operator
+                name: {{ include "kubevisor.fullname" . }}-controller
                 port:
                   number: 80
 {{- end -}}

--- a/incubator/kubevisor/values.yaml
+++ b/incubator/kubevisor/values.yaml
@@ -38,6 +38,10 @@ dashboard:
     tag: latest
     pullPolicy: Always
 
+  graphqlEndpoint:
+    http: https://status.link-society.com/controller/graphql
+    ws: wss://status.link-society.com/controller/graphql
+
 ingress:
   enabled: yes
 


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :bug: Fix missing rename of `operator` to `controller`
 - [x] :wrench: Configure Dashboard's GraphQL endpoints from chart values