### PR TITLE
🐛 Fix ingress annotations in Kubevisor Chart

### DIFF
--- a/incubator/kubevisor/templates/ingress.yaml
+++ b/incubator/kubevisor/templates/ingress.yaml
@@ -13,9 +13,9 @@ metadata:
     app.kubernetes.io/part-of: kubevisor
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
-{{- range $annotation, $value := .Values.ingress.annotations -}}
-    {{ $annotation }}: {{ $value }}
-{{- end -}}
+    {{ if .Values.ingress.annotations }}
+    {{ .Values.ingress.annotations | toYaml | nindent 4 }}
+    {{ end}}
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :bug: Use `| toYaml` to inject custom annotations in Ingress resource