### PR TITLE
🐛 Fix Ingress paths in Kubevisor Chart

### DIFF
--- a/incubator/kubevisor/templates/ingress.yaml
+++ b/incubator/kubevisor/templates/ingress.yaml
@@ -25,7 +25,7 @@ spec:
     - host: {{ .Values.ingress.host }}
       http:
         paths:
-{{- if .Values.controller.enabled -}}
+{{ if .Values.controller.enabled }}
           - path: /controller
             pathType: Prefix
             backend:
@@ -33,8 +33,8 @@ spec:
                 name: {{ include "kubevisor.fullname" . }}-controller
                 port:
                   number: 80
-{{- end -}}
-{{- if .Values.dashboard.enabled -}}
+{{ end }}
+{{ if .Values.dashboard.enabled }}
           - path: /
             pathType: Prefix
             backend:
@@ -42,5 +42,5 @@ spec:
                 name: {{ include "kubevisor.fullname" . }}-dashboard
                 port:
                   number: 80
-{{- end -}}
+{{ end }}
 {{- end -}}


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :bug: `{{- ... -}}` removes newlines before and after, change it to `{{ ... }}`