### PR TITLE
🐛 Set correct path for Kubevisor Dashboard Ingress

### DIFF
--- a/incubator/kubevisor/templates/ingress.yaml
+++ b/incubator/kubevisor/templates/ingress.yaml
@@ -35,7 +35,7 @@ spec:
                   number: 80
 {{ end }}
 {{ if .Values.dashboard.enabled }}
-          - path: /
+          - path: /?(.*)
             pathType: Prefix
             backend:
               service:


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :bug: Set Ingress route to `/?(.*)`
