### PR TITLE
🐛 Disable cache for controller and add ingress class in Kubevisor chart

### DIFF
--- a/incubator/kubevisor/templates/ingress.yaml
+++ b/incubator/kubevisor/templates/ingress.yaml
@@ -12,7 +12,12 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: kubevisor
   annotations:
+    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($request_uri ~ "^/controller/(.*)$") {
+        add_header Cache-Control "no-cache,no-store";
+      }
     {{ if .Values.ingress.annotations }}
     {{ .Values.ingress.annotations | toYaml | nindent 4 }}
     {{ end}}


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :wrench: Disable cache for `/controller/*` routes
 - [x] :wrench: Specify Ingress Class for GKE environments
