### PR TITLE
🐛 Switch value source with 'kind' property #kubirds

### DIFF
--- a/incubator/kubirds/templates/controller/statefulset.yaml
+++ b/incubator/kubirds/templates/controller/statefulset.yaml
@@ -58,9 +58,17 @@ spec:
             - source /opt/kubirds/env && yarn start
           env:
             - name: RABBITMQ_URL
-              {{ .Values.controller.rabbitUrl | toYaml | nindent 14 }}
+            {{ if eq "static" .Values.controller.rabbitUrl.kind }}
+              {{ .Values.controller.rabbitUrl.static | toYaml | nindent 14 }}
+            {{ else }}
+              {{ .Values.controller.rabbitUrl.dynamic | toYaml | nindent 14 }}
+            {{ end }}
             - name: KUBIRDS_REDIS_HOST
-              {{ .Values.controller.redis.host | toYaml | nindent 14 }}
+            {{ if eq "static" .Values.controller.redis.host.kind }}
+              {{ .Values.controller.redis.host.static | toYaml | nindent 14 }}
+            {{ else }}
+              {{ .Values.controller.redis.host.dynamic | toYaml | nindent 14 }}
+            {{ end }}
           envFrom:
             - configMapRef:
                 name: {{ include "kubirds.fullname" . }}-controller

--- a/incubator/kubirds/values.yaml
+++ b/incubator/kubirds/values.yaml
@@ -17,7 +17,14 @@ controller:
 
   redis:
     host:
-      value: http://localhost:6739
+      kind: static
+      static:
+        value: http://localhost:6739
+      dynamic:
+        valueFrom:
+          secretKeyRef:
+            name: kubirds-redis-access
+            key: REDIS_HOST
 
     image:
       name: redis
@@ -27,7 +34,14 @@ controller:
   serviceAccountName: default
 
   rabbitUrl:
-    value: amqp://guest:guest@localhost:5672/
+    kind: static
+    static:
+      value: amqp://guest:guest@localhost:5672/
+    dynamic:
+      valueFrom:
+        secretKeyRef:
+          name: kubirds-rabbitmq-access
+          key: RABBITMQ_URL
 
 dashboard:
   enabled: yes


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :wrench: add `kind` property to `controller.rabbitUrl` (defaults to `static`)
 - [x] :wrench: add `kind` property to `controller.redis.host` (defaults to `static`)
 - [x] :hammer: Use `controller.rabbitUrl.static` or `controller.rabbitUrl.dynamic` according to `kind` 
 - [x] :hammer: Use `controller.redis.host.static` or `controller.redis.host.dynamic` according to `kind`

When using the [FluxCD Operator](https://github.com/fluxcd/helm-operator), setting `value` to `null` will get ignored when applying the `HelmRelease` resource.