### PR TITLE
📦 Add kubirds telegram message reactor

### DIFF
--- a/incubator/kubirds-telegram-message-reactor/.helmignore
+++ b/incubator/kubirds-telegram-message-reactor/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/incubator/kubirds-telegram-message-reactor/Chart.yaml
+++ b/incubator/kubirds-telegram-message-reactor/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: kubirds-telegram-message-reactor
+description: Parametrable Telegram Message Reactor for Kubirds
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/incubator/kubirds-telegram-message-reactor/templates/_helpers.tpl
+++ b/incubator/kubirds-telegram-message-reactor/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kubirds-telegram-message-reactor.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kubirds-telegram-message-reactor.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubirds-telegram-message-reactor.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kubirds-telegram-message-reactor.labels" -}}
+helm.sh/chart: {{ include "kubirds-telegram-message-reactor.chart" . }}
+{{ include "kubirds-telegram-message-reactor.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kubirds-telegram-message-reactor.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubirds-telegram-message-reactor.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kubirds-telegram-message-reactor.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kubirds-telegram-message-reactor.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/incubator/kubirds-telegram-message-reactor/templates/reactor.yaml
+++ b/incubator/kubirds-telegram-message-reactor/templates/reactor.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kubirds.com/v1
+kind: Reactor
+metadata:
+  name: {{ include "kubirds-telegram-message-reactor.fullname" . }}
+  labels:
+    {{- include "kubirds-telegram-message-reactor.labels" . | nindent 4 }}
+    {{ if .Values.labels }}
+    {{ .Values.labels | toYaml | nindent 4 }}
+    {{ end}}
+spec:
+  unitSelector:
+    {{ if .Values.unitSelector }}
+    {{ .Values.unitSelector | toYaml | nindent 4 }}
+    {{ end}}
+  image:
+    name: {{ .Values.image.name }}
+    pullPolicy: {{ .Values.image.pullPolicy }}
+  triggers:
+    success: {{ .Values.triggers.success }}
+    failure: {{ .Values.triggers.failure }}
+    fixed: {{ .Values.triggers.fixed }}
+    regression: {{ .Values.triggers.regression }}

--- a/incubator/kubirds-telegram-message-reactor/values.yaml
+++ b/incubator/kubirds-telegram-message-reactor/values.yaml
@@ -1,0 +1,20 @@
+---
+
+# User Configuration
+
+schedule: every 5 minutes
+
+labels: {}
+unitSelector: {}
+
+triggers:
+  success: yes
+  failure: yes
+  fixed: no
+  regression: no
+
+# Internal Configuration (can be overidden)
+
+image:
+  name: ghcr.io/link-society/kubirds-reactor-telegram-message
+  pullPolicy: IfNotPresent


### PR DESCRIPTION
This PR aims to add the incubator chart reactor "kubirds-telegram-message"

## When this PR will be ready ?

- [x] 📦 helm chart
- [x] 🔧 Provide default configuration for Docker images
- [ ] ✅ Test Reactor

## Usage

```
$ helm install telegram-message link-society-incubator/kubirds-telegram-message-reactor \
    --namespace default \
    --set dbms="postgres" \
    --set secretName="pg-credentials"
```