### PR TITLE
🐛 Fix service template in Kubirds chart

### DIFF
--- a/incubator/kubirds/templates/service.yaml
+++ b/incubator/kubirds/templates/service.yaml
@@ -20,4 +20,3 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "kubirds.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end -}}


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :bug: Remove `{{ end }}` tag in `Service` template