### PR TITLE
✨ Add readiness probe to Kubirds deployment

### DIFF
--- a/incubator/kubirds/templates/deployment.yaml
+++ b/incubator/kubirds/templates/deployment.yaml
@@ -44,3 +44,9 @@ spec:
             - name: http
               containerPort: 5000
               protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :sparkles: Add readiness probe to Kubirds chart (HTTP GET to `/health`)

This will mark the pod as `Unready` as long as the healthcheck doesn't return a `200 OK` response.