### PR TITLE
✨ Add RBAC to Kubirds chart

### DIFF
--- a/incubator/kubirds/templates/cluster-role-binding.yml
+++ b/incubator/kubirds/templates/cluster-role-binding.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kubirds.fullname" . }}-operator-minimal
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kubirds.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "kubirds.fullname" . }}-operator-minimal
+  apiGroup: rbac.authorization.k8s.io

--- a/incubator/kubirds/templates/cluster-role.yaml
+++ b/incubator/kubirds/templates/cluster-role.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kubirds.fullname" . }}-operator-minimal
+rules:
+  - apiGroups: ["tekton.dev"]
+    resources: ["pipelines", "pipelineruns"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+  - apiGroups: ["kubirds.com"]
+    resources: ["units", "reactors", "inhibitors"]
+    verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]

--- a/incubator/kubirds/templates/configMap.yaml
+++ b/incubator/kubirds/templates/configMap.yaml
@@ -17,4 +17,4 @@ data:
   KUBIRDS_REDIS_IMAGE_NAME: "{{ .Values.redis.image.name }}:{{ .Values.redis.image.tag }}"
   KUBIRDS_REDIS_IMAGE_PULL_POLICY: "{{ .Values.redis.image.pullPolicy }}"
   KUBIRDS_REDIS_SECRET_NAME: "{{ include "kubirds.fullname" . }}-redis"
-  KUBIRDS_SERVICEACCOUNT: "{{ .Values.serviceAccountName }}"
+  KUBIRDS_SERVICEACCOUNT: "{{ .Values.pipelineServiceAccount }}"

--- a/incubator/kubirds/templates/deployment.yaml
+++ b/incubator/kubirds/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
         app.kubernetes.io/name: {{ include "kubirds.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ include "kubirds.fullname" . }}
       {{- with .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/incubator/kubirds/templates/service-account.yaml
+++ b/incubator/kubirds/templates/service-account.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kubirds.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ template "kubirds.chart" . }}
+    app.kubernetes.io/name: {{ template "kubirds.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: kubirds

--- a/incubator/kubirds/values.yaml
+++ b/incubator/kubirds/values.yaml
@@ -26,7 +26,7 @@ redis:
     tag: alpine
     pullPolicy: IfNotPresent
 
-serviceAccountName: default
+pipelineServiceAccount: default
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :sparkles: Create `ServiceAccount` for Kubirds' deployment
 - [x] :sparkles: Create `ClusterRole` to access **Tekton** and **Kubirds** resources
 - [x] :sparkles: Add `ClusterRoleBinding`
 - [x] :recycle: :boom: Rename value `serviceAccountName` to `pipelineServiceAccount` (since it will be used for Tekton pipeline runs)