### PR TITLE
✨ Add headless Service for EPMD and configuration for Elixir Node in Kubirds chart

### DIFF
--- a/incubator/kubirds/templates/configMap.yaml
+++ b/incubator/kubirds/templates/configMap.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: kubirds
 data:
-  KUBIRDS_SERVICE_NAME: "{{ include "kubirds.fullname" . }}"
+  KUBIRDS_SERVICE_NAME: "{{ include "kubirds.fullname" . }}-headless"
   KUBIRDS_STATUS_IMAGE_NAME: "{{ .Values.statusImage.name }}:{{ .Values.statusImage.tag }}"
   KUBIRDS_STATUS_IMAGE_PULL_POLICY: {{ .Values.statusImage.pullPolicy }}
   KUBIRDS_REDIS_IMAGE_NAME: "{{ .Values.redis.image.name }}:{{ .Values.redis.image.tag }}"

--- a/incubator/kubirds/templates/deployment.yaml
+++ b/incubator/kubirds/templates/deployment.yaml
@@ -38,8 +38,6 @@ spec:
             {{ else }}
               {{ .Values.redis.host.dynamic | toYaml | nindent 14 }}
             {{ end }}
-            - name: RELEASE_DISTRIBUTION
-              value: name
             - name: RELEASE_NODE_IP
               valueFrom:
                 fieldRef:

--- a/incubator/kubirds/templates/deployment.yaml
+++ b/incubator/kubirds/templates/deployment.yaml
@@ -38,12 +38,27 @@ spec:
             {{ else }}
               {{ .Values.redis.host.dynamic | toYaml | nindent 14 }}
             {{ end }}
+            - name: RELEASE_DISTRIBUTION
+              value: name
+            - name: RELEASE_NODE
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: RELEASE_COOKIE
+            {{ if eq "static" .Values.erlangCookie.kind }}
+              {{ .Values.erlangCookie.static | toYaml | nindent 14 }}
+            {{ else }}
+              {{ .Values.erlangCookie.dynamic | toYaml | nindent 14 }}
+            {{ end }}
           envFrom:
             - configMapRef:
                 name: {{ include "kubirds.fullname" . }}
           ports:
             - name: http
               containerPort: 5000
+              protocol: TCP
+            - name: epmd
+              containerPort: 4369
               protocol: TCP
           readinessProbe:
             httpGet:

--- a/incubator/kubirds/templates/deployment.yaml
+++ b/incubator/kubirds/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
             {{ end }}
             - name: RELEASE_DISTRIBUTION
               value: name
-            - name: RELEASE_NODE
+            - name: RELEASE_NODE_IP
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP

--- a/incubator/kubirds/templates/service-headless.yaml
+++ b/incubator/kubirds/templates/service-headless.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kubirds.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ include "kubirds.chart" . }}
+    app.kubernetes.io/name: {{ include "kubirds.name" . }}-headless
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: kubirds
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: 4369
+      targetPort: epmd
+      protocol: TCP
+      name: epmd
+  selector:
+    app.kubernetes.io/name: {{ include "kubirds.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/incubator/kubirds/values.yaml
+++ b/incubator/kubirds/values.yaml
@@ -26,6 +26,16 @@ redis:
     tag: alpine
     pullPolicy: IfNotPresent
 
+erlangCookie:
+  kind: static
+  static:
+    value: ""
+  dynamic:
+    valueFrom:
+      secretKeyRef:
+        name: kubirds-erlang-cookie
+        key: ERLANG_COOKIE
+
 pipelineServiceAccount: default
 
 nameOverride: ""


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :sparkles: Add headless `Service` (with `.spec.clusterIP` set to `None`
 - [x] :wrench: Add environment variable `RELEASE_NODE_IP` and `RELEASE_COOKIE` to setup the Elixir node
 - [x] :wrench: Add `erlangCookie` object to `values.yaml`

**NB:** If the cookie is not set (the default), the launcher script from the Docker image will generate a random one. This prevent the usage of the default one shipped with the release inside the Docker image (which would be unsafe).

**NB:** The `RELEASE_NODE_IP` will be used by the launcher script from the Docker image to compute the `RELEASE_NODE` variable: `${DATAPIO_APP_NAME}@${RELEASE_NODE_IP}`