### PR TITLE
:bug: Add missing history field to Unit CRD in Kubirds chart

### DIFF
--- a/incubator/kubirds/crds/unit.yml
+++ b/incubator/kubirds/crds/unit.yml
@@ -90,6 +90,8 @@ spec:
                         type: object
                     type: object
                   type: array
+                history:
+                  type: number
                 image:
                   properties:
                     command:


### PR DESCRIPTION
This PR introduces the following changes:

 - [x] :bug: Add missing `history` field to `Unit` CRD schema