### PR TITLE
:bug: Add missing HTTPS scheme to readiness probe in Kubirds chart

### DIFF
--- a/incubator/kubirds/templates/deployment.yaml
+++ b/incubator/kubirds/templates/deployment.yaml
@@ -68,6 +68,7 @@ spec:
               protocol: TCP
           readinessProbe:
             httpGet:
+              scheme: HTTPS
               path: /health
               port: https
             initialDelaySeconds: 30


### PR DESCRIPTION
**This PR provides the following changes:**

 - [x] Set `scheme` to `HTTPS` in deployment's readiness probe