### PR TITLE
:sparkles: Add Events API permissions in Kubirds Chart

### DIFF
--- a/incubator/kubirds/templates/cluster-role.yaml
+++ b/incubator/kubirds/templates/cluster-role.yaml
@@ -19,22 +19,25 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["create", "update", "patch", "delete"]
+  - apiGroups: ["events.k8s.io"]
+    resources: ["events"]
+    verbs: ["get", "watch", "list", "create"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kubirds.fullname" . }}-status-updater
+  name: {{ include "kubirds.fullname" . }}-apiclient
   labels:
     helm.sh/chart: {{ include "kubirds.chart" . }}
-    app.kubernetes.io/name: {{ include "kubirds.name" . }}-status-updater
+    app.kubernetes.io/name: {{ include "kubirds.name" . }}-apiclient
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: kubirds
 rules:
-  - apiGroups: ["kubirds.com"]
-    resources: ["units"]
-    verbs: ["patch"]
+  - apiGroups: ["api.kubirds.com"]
+    nonResources: ["/apis/api.kubirds.com/v1"]
+    verbs: ["post"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/incubator/kubirds/templates/configMap.yaml
+++ b/incubator/kubirds/templates/configMap.yaml
@@ -17,4 +17,3 @@ data:
   KUBIRDS_REDIS_IMAGE_NAME: "{{ .Values.redis.image.name }}:{{ .Values.redis.image.tag }}"
   KUBIRDS_REDIS_IMAGE_PULL_POLICY: "{{ .Values.redis.image.pullPolicy }}"
   KUBIRDS_REDIS_SECRET_NAME: "{{ include "kubirds.fullname" . }}-redis"
-  KUBIRDS_SERVICEACCOUNT: "{{ .Values.pipelineServiceAccount }}"

--- a/incubator/kubirds/values.yaml
+++ b/incubator/kubirds/values.yaml
@@ -6,7 +6,7 @@ image:
   pullSecrets: []
 
 statusImage:
-  name: lachlanevenson/k8s-kubectl
+  name: alpine
   tag: latest
   pullPolicy: IfNotPresent
 
@@ -35,8 +35,6 @@ erlangCookie:
       secretKeyRef:
         name: kubirds-erlang-cookie
         key: ERLANG_COOKIE
-
-pipelineServiceAccount: default
 
 tls:
   caBundle: null


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :sparkles: :lock: Add permissions on `Event` resources
 - [x] :wrench: :fire: Remove obsolete `pipelineServiceAccount` value
