### PR TITLE
:bug: Fix API Client RBAC in Kubirds chart

### DIFF
--- a/incubator/kubirds/templates/cluster-role.yaml
+++ b/incubator/kubirds/templates/cluster-role.yaml
@@ -36,8 +36,8 @@ metadata:
     app.kubernetes.io/part-of: kubirds
 rules:
   - apiGroups: ["api.kubirds.com"]
-    nonResources: ["/apis/api.kubirds.com/v1"]
-    verbs: ["post"]
+    nonResourceURLs: ["/apis/api.kubirds.com/v1"]
+    verbs: ["get", "post"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :bug: Rename field `nonResources` to `nonResourceURLs`