### PR TITLE
:bug: :lock: Fix API Client RBAC rule in Kubirds chart

### DIFF
--- a/incubator/kubirds/templates/cluster-role.yaml
+++ b/incubator/kubirds/templates/cluster-role.yaml
@@ -35,8 +35,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: kubirds
 rules:
-  - apiGroups: ["api.kubirds.com"]
-    nonResourceURLs: ["/apis/api.kubirds.com/v1"]
+  - nonResourceURLs: ["/apis/api.kubirds.com/v1"]
     verbs: ["get", "post"]
 
 ---


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :bug: Remove `apiGroup` field (cannot be added with `nonResourceURLs` field)