### PR TITLE
:bug: Add missing API Group for event RBAC in Kubirds Chart

### DIFF
--- a/incubator/kubirds/templates/cluster-role.yaml
+++ b/incubator/kubirds/templates/cluster-role.yaml
@@ -19,7 +19,7 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["create", "update", "patch", "delete"]
-  - apiGroups: ["events.k8s.io"]
+  - apiGroups: ["", "events.k8s.io"]
     resources: ["events"]
     verbs: ["get", "watch", "list", "create"]
 


### PR DESCRIPTION
This PR provides the following changes:

 - :passport_control: add Core API Group to `operator-minimal` cluster role