### PR TITLE
:sparkles: Add tlsctl job

### DIFF
--- a/incubator/kubirds/charts/operator/templates/_helpers.tpl
+++ b/incubator/kubirds/charts/operator/templates/_helpers.tpl
@@ -64,3 +64,18 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+API Service
+*/}}
+{{- define "kubirds-operator.apiServiceName" -}}
+v1.api.kubirds.com
+{{- end }}
+
+{{- define "kubirds-operator.apiServiceVersion" -}}
+v1
+{{- end }}
+
+{{- define "kubirds-operator.apiServiceGroup" -}}
+api.kubirds.com
+{{- end }}

--- a/incubator/kubirds/charts/operator/templates/api-aggregation-tls.yaml
+++ b/incubator/kubirds/charts/operator/templates/api-aggregation-tls.yaml
@@ -1,8 +1,9 @@
+{{- $days := 60 -}}
 {{- $caName := printf "%s-ca" (include "kubirds-operator.name" .) -}}
 {{- $commonName := include "kubirds-operator.fullname" . -}}
 {{- $dnsNames := list (printf "%s.%s" (include "kubirds-operator.fullname" .) .Release.Namespace) (printf "%s.%s.svc" (include "kubirds-operator.fullname" .) .Release.Namespace) -}}
-{{- $ca := genCA $caName 365 -}}
-{{- $cert := genSignedCert $commonName nil $dnsNames 365 $ca -}}
+{{- $ca := genCA $caName $days -}}
+{{- $cert := genSignedCert $commonName nil $dnsNames $days $ca -}}
 {{- $caBundle := printf "%s\n%s\n" $ca.Cert $ca.Key -}}
 
 ---
@@ -22,13 +23,13 @@ data:
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
-  name: v1.api.kubirds.com
+  name: {{- include "kubirds-operator.apiServiceName" . }}
   labels:
     {{- include "kubirds-operator.labels" . | nindent 4 }}
 spec:
-  group: api.kubirds.com
+  group: {{ include "kubirds-operator.apiServiceGroup" . }}
   groupPriorityMinimum: 100
-  version: v1
+  version: {{ include "kubirds-operator.apiServiceVersion" . }}
   versionPriority: 100
   service:
     name: {{ include "kubirds-operator.fullname" . }}

--- a/incubator/kubirds/charts/operator/templates/configuration/configMap.yaml
+++ b/incubator/kubirds/charts/operator/templates/configuration/configMap.yaml
@@ -15,3 +15,6 @@ data:
 
   KUBIRDS_CACHELOG_IMAGE_NAME: "{{ .Values.cachelogImage.name }}:{{ .Values.cachelogImage.tag }}"
   KUBIRDS_CACHELOG_IMAGE_PULL_POLICY: "{{ .Values.cachelogImage.pullPolicy }}"
+
+  KUBIRDS_TLS_SECRET_NAME: "{{ include "kubirds-operator.fullname" . }}-tls"
+  KUBIRDS_API_SERVICE_NAME: "{{ include "kubirds-operator.kubirds-operator.apiServiceName" . }}"

--- a/incubator/kubirds/charts/operator/templates/tlsctl-cronjob.yaml
+++ b/incubator/kubirds/charts/operator/templates/tlsctl-cronjob.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "kubirds-operator.fullname" . }}-tlsctl
+  labels:
+    {{- include "kubirds-operator.labels" . | nindent 4 }}
+spec:
+  schedule: "0 0 1 * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: tlsctl
+              image: "{{ .Values.tlsctlImage.name }}:{{ .Values.tlsctlImage.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.tlsctlImage.pullPolicy }}
+              envFrom:
+                - configMapRef:
+                    name: {{ include "kubirds-operator.fullname" . }}

--- a/incubator/kubirds/charts/operator/values.yaml
+++ b/incubator/kubirds/charts/operator/values.yaml
@@ -10,6 +10,11 @@ image:
   pullPolicy: IfNotPresent
   pullSecrets: []
 
+tlsctlImage:
+  name: linksociety/kubirds-tlsctl
+  tag: 2.0.0-alpha1
+  pullPolicy: IfNotPresent
+
 cachelogImage:
   name: redis
   tag: 6.2.6-alpine


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :wrench: Add configuration values for `tlsctl`
 - [x] :sparkles: Add `tlsctl` job to renew certificates
 - [x] :wrench: Make APIService name configurable
